### PR TITLE
FLTK Settings including Invert Z Axis, Model Overrides, Shader Overrides

### DIFF
--- a/Editor/Assets/Shaders/Crystal.shader
+++ b/Editor/Assets/Shaders/Crystal.shader
@@ -15,7 +15,7 @@ Shader "Custom/Crystal"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/DualTextureEnvRigid.shader
+++ b/Editor/Assets/Shaders/DualTextureEnvRigid.shader
@@ -14,7 +14,7 @@ Shader "Custom/DualTextureEnvRigid"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/DualTextureEnvSkin.shader
+++ b/Editor/Assets/Shaders/DualTextureEnvSkin.shader
@@ -15,7 +15,7 @@ Shader "Custom/DualTextureEnvSkin"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/DualTextureRigid.shader
+++ b/Editor/Assets/Shaders/DualTextureRigid.shader
@@ -13,7 +13,7 @@ Shader "Custom/DualTextureRigid"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/DualTextureRigidAlpha.shader
+++ b/Editor/Assets/Shaders/DualTextureRigidAlpha.shader
@@ -15,7 +15,7 @@ Shader "Custom/DualTextureRigidAlpha"
     {
         Tags { "RenderType" = "TransparentCutout" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/DualTextureRigidGlow.shader
+++ b/Editor/Assets/Shaders/DualTextureRigidGlow.shader
@@ -13,7 +13,7 @@ Shader "Custom/DualTextureRigidGlow"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/DualTextureRigidGlowNoShadow.shader
+++ b/Editor/Assets/Shaders/DualTextureRigidGlowNoShadow.shader
@@ -13,7 +13,7 @@ Shader "Custom/DualTextureRigidGlowNoShadow"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/DualTextureRigidNoShadow.shader
+++ b/Editor/Assets/Shaders/DualTextureRigidNoShadow.shader
@@ -13,7 +13,7 @@ Shader "Custom/DualTextureRigidNoShadow"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/DualTextureSkin2UV.shader
+++ b/Editor/Assets/Shaders/DualTextureSkin2UV.shader
@@ -13,7 +13,7 @@ Shader "Custom/DualTextureSkin2UV"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/DualTextureSkin2UVGlow.shader
+++ b/Editor/Assets/Shaders/DualTextureSkin2UVGlow.shader
@@ -14,7 +14,7 @@ Shader "Custom/DualTextureSkin2UVGlow"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/EnvRigid.shader
+++ b/Editor/Assets/Shaders/EnvRigid.shader
@@ -13,7 +13,7 @@ Shader "Custom/EnvRigid"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/EnvSkin.shader
+++ b/Editor/Assets/Shaders/EnvSkin.shader
@@ -15,7 +15,7 @@ Shader "Custom/EnvSkin"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/GhostRigid.shader
+++ b/Editor/Assets/Shaders/GhostRigid.shader
@@ -13,7 +13,7 @@ Shader "Custom/GhostRigid"
     {
         Tags { "Queue" = "Transparent" "RenderType" = "Transparent" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/HologramRigid.shader
+++ b/Editor/Assets/Shaders/HologramRigid.shader
@@ -23,7 +23,7 @@ Shader "Custom/HologramRigid"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/RuntimeTerrain_0.shader
+++ b/Editor/Assets/Shaders/RuntimeTerrain_0.shader
@@ -8,7 +8,7 @@ Shader "Custom/RuntimeTerrain_0"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/RuntimeTerrain_1.shader
+++ b/Editor/Assets/Shaders/RuntimeTerrain_1.shader
@@ -11,7 +11,7 @@ Shader "Custom/RuntimeTerrain_1"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/RuntimeTerrain_2.shader
+++ b/Editor/Assets/Shaders/RuntimeTerrain_2.shader
@@ -13,7 +13,7 @@ Shader "Custom/RuntimeTerrain_2"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/RuntimeTerrain_3.shader
+++ b/Editor/Assets/Shaders/RuntimeTerrain_3.shader
@@ -15,7 +15,7 @@ Shader "Custom/RuntimeTerrain_3"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/RuntimeTerrain_4.shader
+++ b/Editor/Assets/Shaders/RuntimeTerrain_4.shader
@@ -17,7 +17,7 @@ Shader "Custom/RuntimeTerrain_4"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/RuntimeTerrain_5.shader
+++ b/Editor/Assets/Shaders/RuntimeTerrain_5.shader
@@ -19,7 +19,7 @@ Shader "Custom/RuntimeTerrain_5"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/ShieldRigid.shader
+++ b/Editor/Assets/Shaders/ShieldRigid.shader
@@ -29,7 +29,7 @@ Shader "Custom/ShieldRigid"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/SimpleRigid.shader
+++ b/Editor/Assets/Shaders/SimpleRigid.shader
@@ -14,7 +14,7 @@ Shader "Custom/SimpleRigid"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/SimpleRigidAlphaScreen.shader
+++ b/Editor/Assets/Shaders/SimpleRigidAlphaScreen.shader
@@ -13,7 +13,7 @@ Shader "Custom/SimpleRigidAlphaScreen"
     {
         Tags { "Queue" = "AlphaTest" "RenderType" = "TransparentCutout" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/SimpleRigidNoShadow.shader
+++ b/Editor/Assets/Shaders/SimpleRigidNoShadow.shader
@@ -14,7 +14,7 @@ Shader "Custom/SimpleRigidNoShadow"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/SimpleSkin.shader
+++ b/Editor/Assets/Shaders/SimpleSkin.shader
@@ -17,7 +17,7 @@ Shader "Custom/SimpleSkin"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/SpecGlowRigid.shader
+++ b/Editor/Assets/Shaders/SpecGlowRigid.shader
@@ -12,7 +12,7 @@ Shader "Custom/SpecGlowRigid"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/SpecGlowSkin.shader
+++ b/Editor/Assets/Shaders/SpecGlowSkin.shader
@@ -12,7 +12,7 @@ Shader "Custom/SpecGlowSkin"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/SpecRigid.shader
+++ b/Editor/Assets/Shaders/SpecRigid.shader
@@ -11,7 +11,7 @@ Shader "Custom/SpecRigid"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/SpecRigidAlphaTest.shader
+++ b/Editor/Assets/Shaders/SpecRigidAlphaTest.shader
@@ -11,7 +11,7 @@ Shader "Custom/SpecRigidAlphaTest"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/SpecSkin.shader
+++ b/Editor/Assets/Shaders/SpecSkin.shader
@@ -12,7 +12,7 @@ Shader "Custom/SpecSkin"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/SpecSkinAlphaTest.shader
+++ b/Editor/Assets/Shaders/SpecSkinAlphaTest.shader
@@ -11,7 +11,7 @@ Shader "Custom/SpecSkinAlphaTest"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/TintMaskRigid.shader
+++ b/Editor/Assets/Shaders/TintMaskRigid.shader
@@ -11,7 +11,7 @@ Shader "Custom/TintMaskRigid"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/TintMaskSkin.shader
+++ b/Editor/Assets/Shaders/TintMaskSkin.shader
@@ -12,7 +12,7 @@ Shader "Custom/TintMaskSkin"
     {
         Tags { "RenderType" = "Opaque" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/Assets/Shaders/TintMaskSkinAlphaTest.shader
+++ b/Editor/Assets/Shaders/TintMaskSkinAlphaTest.shader
@@ -18,7 +18,7 @@ Shader "Custom/TintMaskSkinAlphaTest"
     {
         Tags { "Queue" = "AlphaTest" "RenderType" = "TransparentCutout" }
         LOD 200
-        Cull Front
+        Cull Off
 
         CGPROGRAM
 

--- a/Editor/FileTypes/Dme/MeshEntry.cs
+++ b/Editor/FileTypes/Dme/MeshEntry.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using UnityEngine;
 
 using ForgeLightToolkit.Editor.FileTypes.Dma;
+using ForgeLightToolkit.Settings;
 
 namespace ForgeLightToolkit.Editor.FileTypes.Dme
 {
@@ -27,9 +28,12 @@ namespace ForgeLightToolkit.Editor.FileTypes.Dme
 
         public Mesh Mesh;
 
-        public bool CreateMesh(string name, MaterialEntry materialEntry)
+        public bool CreateMesh(string name, MaterialEntry materialEntry, int meshIndex)
         {
-            Mesh = new Mesh();
+            Mesh = new Mesh
+            {
+                name = $"{name}_Mesh_{meshIndex}",
+            };
 
             var materialDefinition = MaterialInfo.Instance.MaterialDefinitions.SingleOrDefault(x => x.NameHash == materialEntry.Hash);
 
@@ -72,6 +76,11 @@ namespace ForgeLightToolkit.Editor.FileTypes.Dme
                     var y = BitConverter.ToSingle(VertexBuffer, positionEntry.Offset + i * VertexSize + 4);
                     var z = BitConverter.ToSingle(VertexBuffer, positionEntry.Offset + i * VertexSize + 8);
 
+                    if (FLTKSettings.Instance.InvertZ)
+                    {
+                        z = -z;
+                    }
+
                     vertices[i] = new Vector3(x, y, z);
                 }
             }
@@ -100,6 +109,11 @@ namespace ForgeLightToolkit.Editor.FileTypes.Dme
                         var x = BitConverter.ToSingle(VertexBuffer, startIndex + 0);
                         var y = BitConverter.ToSingle(VertexBuffer, startIndex + 4);
                         var z = BitConverter.ToSingle(VertexBuffer, startIndex + 8);
+
+                        if (FLTKSettings.Instance.InvertZ)
+                        {
+                            z = -z;
+                        }
 
                         normals[i] = new Vector3(x, y, z);
                     }

--- a/Editor/FileTypes/DmeFile.cs
+++ b/Editor/FileTypes/DmeFile.cs
@@ -73,7 +73,7 @@ namespace ForgeLightToolkit.Editor.FileTypes
                 {
                     var materialEntry = DmaFile.MaterialEntries[meshEntry.MaterialIndex];
 
-                    if (!meshEntry.CreateMesh(name, materialEntry))
+                    if (!meshEntry.CreateMesh(name, materialEntry, i))
                         return false;
 
                     Meshes.Add(meshEntry);

--- a/Editor/FileTypes/Gcnk/RawLight.cs
+++ b/Editor/FileTypes/Gcnk/RawLight.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ForgeLightToolkit.Settings;
+using System;
 
 using UnityEngine;
 
@@ -26,6 +27,11 @@ namespace ForgeLightToolkit.Editor.FileTypes.Gcnk
             Type = reader.ReadByte();
 
             Position = reader.ReadVector4();
+            
+            if (FLTKSettings.Instance.InvertZ)
+            {
+                Position.z = -Position.z;
+            }
 
             Range = reader.ReadSingle();
             Intensity = reader.ReadSingle();

--- a/Editor/FileTypes/Gcnk/RuntimeObject.cs
+++ b/Editor/FileTypes/Gcnk/RuntimeObject.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ForgeLightToolkit.Settings;
+using System;
 using System.Collections.Generic;
 
 using UnityEngine;
@@ -58,7 +59,17 @@ namespace ForgeLightToolkit.Editor.FileTypes.Gcnk
 
             Position = reader.ReadVector4();
 
+            if (FLTKSettings.Instance.InvertZ)
+            {
+                Position.z = -Position.z;
+            }
+
             Rotation = reader.ReadVector4();
+
+            if (FLTKSettings.Instance.InvertZ)
+            {
+                Rotation.x = -1 * Rotation.x;
+            }
 
             Scale = reader.ReadSingle();
 

--- a/Editor/FileTypes/Gcnk/Vertex.cs
+++ b/Editor/FileTypes/Gcnk/Vertex.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using ForgeLightToolkit.Settings;
+using UnityEngine;
 
 namespace ForgeLightToolkit.Editor.FileTypes.Gcnk
 {
@@ -18,9 +19,19 @@ namespace ForgeLightToolkit.Editor.FileTypes.Gcnk
         {
             Position = reader.ReadVector3();
 
+            if (FLTKSettings.Instance.InvertZ)
+            {
+                Position.z = -Position.z;
+            }
+
             Normal.x = reader.ReadByte() / 127.5f - 1;
             Normal.y = reader.ReadByte() / 127.5f - 1;
             Normal.z = reader.ReadByte() / 127.5f - 1;
+
+            if (FLTKSettings.Instance.InvertZ)
+            {
+                Normal.z = -Normal.z;
+            }
 
             reader.Skip(1);
 

--- a/Editor/FileTypes/Gzne/FloraData.cs
+++ b/Editor/FileTypes/Gzne/FloraData.cs
@@ -3,6 +3,7 @@ using System;
 using UnityEngine;
 
 using ForgeLightToolkit.Editor;
+using ForgeLightToolkit.Settings;
 
 namespace ForgeLightToolkit
 {
@@ -18,6 +19,11 @@ namespace ForgeLightToolkit
         public void Deserialize(Reader reader)
         {
             Position = reader.ReadVector3();
+
+            if (FLTKSettings.Instance.InvertZ)
+            {
+                Position.z = -Position.z;
+            }
 
             Unknown = reader.ReadByte();
 

--- a/Editor/FileTypes/MapFile.cs
+++ b/Editor/FileTypes/MapFile.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using UnityEngine;
 
 using ForgeLightToolkit.Editor.FileTypes.Map;
+using ForgeLightToolkit.Settings;
 
 namespace ForgeLightToolkit.Editor.FileTypes
 {
@@ -25,6 +26,11 @@ namespace ForgeLightToolkit.Editor.FileTypes
                     Id = reader.ReadInt32(),
                     Position = reader.ReadVector3()
                 };
+
+                if (FLTKSettings.Instance.InvertZ)
+                {
+                    node.Position.z = -node.Position.z;
+                }
 
                 var edgeCount = reader.ReadUInt32();
 

--- a/Editor/LoadWorldWindow.cs
+++ b/Editor/LoadWorldWindow.cs
@@ -9,6 +9,7 @@ using ForgeLightToolkit.Editor.FileTypes;
 using ForgeLightToolkit.Editor.FileTypes.Dma;
 using ForgeLightToolkit.Editor.FileTypes.Map;
 using ForgeLightToolkit.Editor.FileTypes.Gcnk;
+using ForgeLightToolkit.Settings;
 
 namespace ForgeLightToolkit.Editor
 {
@@ -327,7 +328,10 @@ namespace ForgeLightToolkit.Editor
                 }
             }
 
-            worldObject.transform.localScale = new Vector3(1, 1, -1);
+            if (!FLTKSettings.Instance.InvertZ)
+            {
+                worldObject.transform.localScale = new Vector3(1, 1, -1);
+            }
         }
 
         private void LoadAdrFile(string assetsPath, string adrFileName, GameObject parentObject, Vector4 position, float scale, Vector4 rotation, string agrFileName = null)

--- a/Editor/LoadWorldWindow.cs
+++ b/Editor/LoadWorldWindow.cs
@@ -21,7 +21,7 @@ namespace ForgeLightToolkit.Editor
         private bool _loadObjects = true;
         private bool _loadRoadMap = true;
 
-        [MenuItem("ForgeLight/Load World")]
+        [MenuItem("ForgeLight/Load World", priority = 10)]
         public static void ShowWindow()
         {
             GetWindow<LoadWorldWindow>("Load World");

--- a/Editor/LoadWorldWindow.cs
+++ b/Editor/LoadWorldWindow.cs
@@ -188,7 +188,10 @@ namespace ForgeLightToolkit.Editor
 
                         foreach (var tile in gcnkFile.Tiles)
                         {
-                            var chunkMaterial = new Material(Shader.Find($"Custom/RuntimeTerrain_{tile.EcoDataList.Count}"))
+                            var shaderName = $"RuntimeTerrain_{tile.EcoDataList.Count}";
+                            var shader = FLTKSettings.Instance.GetShader(shaderName) ?? Shader.Find($"Custom/{shaderName}");
+
+                            var chunkMaterial = new Material(shader)
                             {
                                 name = $"Tile {tile.Index}"
                             };
@@ -352,6 +355,17 @@ namespace ForgeLightToolkit.Editor
                 return;
             }
 
+            var overrideModel = FLTKSettings.Instance.GetModel(adrFile.ModelFileName);
+            if (overrideModel != null)
+            {
+                GameObject go = Instantiate(overrideModel);
+                go.transform.parent = parentObject.transform;
+                go.transform.localPosition = position;
+                go.transform.localScale = Vector3.one * scale;
+                go.transform.localRotation = Quaternion.Euler(rotation.y * Mathf.Rad2Deg, rotation.x * Mathf.Rad2Deg, rotation.z * Mathf.Rad2Deg);
+                return;
+            }
+
             var dmeFilePath = Path.Combine(assetsPath, adrFile.ModelFileName);
 
             var dmeFile = AssetDatabase.LoadAssetAtPath<DmeFile>(dmeFilePath);
@@ -401,7 +415,7 @@ namespace ForgeLightToolkit.Editor
 
                 meshObject.name = materialDefinition.Name;
 
-                var materialShader = Shader.Find($"Custom/{materialDefinition.Name}");
+                var materialShader = FLTKSettings.Instance.GetShader(materialDefinition.Name) ?? Shader.Find($"Custom/{materialDefinition.Name}");
 
                 if (materialShader is null)
                 {

--- a/Editor/ReimportAllWindow.cs
+++ b/Editor/ReimportAllWindow.cs
@@ -145,7 +145,7 @@ namespace ForgeLightToolkit
 
                 if (types != EnumFileType.None)
                 {
-                    Close();
+                    //Close();
                     reimport(types);
                 }
             }
@@ -196,7 +196,7 @@ namespace ForgeLightToolkit
 
                 if ((typeMask & EnumFileType.Gcnk) == EnumFileType.Gcnk)
                 {
-                    filters.Add("t:adrFile");
+                    filters.Add("t:gcnkFile");
                 }
 
                 if ((typeMask & EnumFileType.Gzne) == EnumFileType.Gzne)

--- a/Editor/ReimportAllWindow.cs
+++ b/Editor/ReimportAllWindow.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+namespace ForgeLightToolkit
+{
+    public class ReimportAllWindow : EditorWindow
+    {
+        [MenuItem("ForgeLight/Reimport All ForgeLight Assets", priority = 11)]
+        public static void ReimportAll()
+        {
+            Debug.Log("Running reimport");
+            // TODO: search for all assets matching the file types, reimport them
+        }
+
+        [MenuItem("ForgeLight/Reimport ForgeLight Assets by type", priority = 12)]
+        public static void OpenReimportWindow()
+        {
+            GetWindow<ReimportAllWindow>("Reimport Wizzard");
+        }
+
+        private void OnGUI()
+        {
+            // TODO: custom window to allow for selecting which types to reimport
+        }
+    }
+}

--- a/Editor/ReimportAllWindow.cs
+++ b/Editor/ReimportAllWindow.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
+using System;
 
 namespace ForgeLightToolkit
 {
@@ -11,7 +12,7 @@ namespace ForgeLightToolkit
         public static void ReimportAll()
         {
             Debug.Log("Running reimport");
-            // TODO: search for all assets matching the file types, reimport them
+            reimport(EnumFileType.ALL);
         }
 
         [MenuItem("ForgeLight/Reimport ForgeLight Assets by type", priority = 12)]
@@ -20,9 +21,218 @@ namespace ForgeLightToolkit
             GetWindow<ReimportAllWindow>("Reimport Wizzard");
         }
 
+        private const int BTN_SPACING = 5;
+
+        private bool adr;
+        private bool agr;
+        private bool dma;
+        private bool dme;
+        private bool gck2;
+        private bool gcnk;
+        private bool gzne;
+        private bool map;
+
         private void OnGUI()
         {
-            // TODO: custom window to allow for selecting which types to reimport
+            GUILayout.BeginArea(new Rect(0, 0, Screen.width / EditorGUIUtility.pixelsPerPoint, Screen.height / EditorGUIUtility.pixelsPerPoint));
+
+            GUILayout.Space(10);
+
+            GUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+
+            GUILayout.Label("Files Types to Reimport", EditorStyles.boldLabel);
+
+            GUILayout.FlexibleSpace();
+            GUILayout.EndHorizontal();
+
+            GUILayout.Space(BTN_SPACING);
+
+            GUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+
+            adr = GUILayout.Toggle(adr, ".adr");
+
+            GUILayout.FlexibleSpace();
+            GUILayout.EndHorizontal();
+
+            GUILayout.Space(BTN_SPACING);
+
+            GUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+
+            agr = GUILayout.Toggle(agr, ".agr");
+
+            GUILayout.FlexibleSpace();
+            GUILayout.EndHorizontal();
+
+            GUILayout.Space(BTN_SPACING);
+
+            GUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+
+            dma = GUILayout.Toggle(dma, ".dma");
+
+            GUILayout.FlexibleSpace();
+            GUILayout.EndHorizontal();
+
+            GUILayout.Space(BTN_SPACING);
+
+            GUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+
+            dme = GUILayout.Toggle(dme, ".dme");
+
+            GUILayout.FlexibleSpace();
+            GUILayout.EndHorizontal();
+
+            GUILayout.Space(BTN_SPACING);
+
+            GUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+
+            map = GUILayout.Toggle(map, ".map");
+
+            GUILayout.FlexibleSpace();
+            GUILayout.EndHorizontal();
+
+            GUILayout.Space(BTN_SPACING);
+
+            GUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+
+            gck2 = GUILayout.Toggle(gck2, ".gck2");
+
+            GUILayout.FlexibleSpace();
+            GUILayout.EndHorizontal();
+
+            GUILayout.Space(BTN_SPACING);
+
+            GUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+
+            gcnk = GUILayout.Toggle(gcnk, ".gcnk");
+
+            GUILayout.FlexibleSpace();
+            GUILayout.EndHorizontal();
+
+            GUILayout.Space(BTN_SPACING);
+
+            GUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+
+            gzne = GUILayout.Toggle(gzne, ".gzne");
+
+            GUILayout.FlexibleSpace();
+            GUILayout.EndHorizontal();
+
+            GUILayout.Space(10);
+
+            GUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+
+            if (GUILayout.Button("Reimport", GUILayout.ExpandWidth(false)))
+            {
+                EnumFileType types = EnumFileType.None;
+                types |= (adr ? EnumFileType.Adr : EnumFileType.None);
+                types |= (agr ? EnumFileType.Agr : EnumFileType.None);
+                types |= (dme ? EnumFileType.Dme : EnumFileType.None);
+                types |= (dma ? EnumFileType.Dma : EnumFileType.None);
+                types |= (map ? EnumFileType.Map : EnumFileType.None);
+                types |= (gck2 ? EnumFileType.Gck2 : EnumFileType.None);
+                types |= (gcnk ? EnumFileType.Gcnk : EnumFileType.None);
+                types |= (gzne ? EnumFileType.Gzne : EnumFileType.None);
+
+                if (types != EnumFileType.None)
+                {
+                    Close();
+                    reimport(types);
+                }
+            }
+
+            GUILayout.FlexibleSpace();
+            GUILayout.EndHorizontal();
+
+            GUILayout.EndArea();
         }
+
+        private static void reimport(EnumFileType typeMask)
+        {
+            try
+            {
+                AssetDatabase.StartAssetEditing();
+
+                List<string> filters = new();
+
+                if ((typeMask & EnumFileType.Adr) == EnumFileType.Adr)
+                {
+                    filters.Add("t:adrFile");
+                }
+
+                if ((typeMask & EnumFileType.Agr) == EnumFileType.Agr)
+                {
+                    filters.Add("t:agrFile");
+                }
+
+                if ((typeMask & EnumFileType.Dma) == EnumFileType.Dma)
+                {
+                    filters.Add("t:dmaFile");
+                }
+
+                if ((typeMask & EnumFileType.Dme) == EnumFileType.Dme)
+                {
+                    filters.Add("t:dmeFile");
+                }
+
+                if ((typeMask & EnumFileType.Map) == EnumFileType.Map)
+                {
+                    filters.Add("t:mapFile");
+                }
+
+                if ((typeMask & EnumFileType.Gck2) == EnumFileType.Gck2)
+                {
+                    filters.Add("t:gck2File");
+                }
+
+                if ((typeMask & EnumFileType.Gcnk) == EnumFileType.Gcnk)
+                {
+                    filters.Add("t:adrFile");
+                }
+
+                if ((typeMask & EnumFileType.Gzne) == EnumFileType.Gzne)
+                {
+                    filters.Add("t:gzneFile");
+                }
+
+                var guids = AssetDatabase.FindAssets(string.Join(' ', filters));
+                foreach (var guid in guids)
+                {
+                    var path = AssetDatabase.GUIDToAssetPath(guid);
+                    AssetDatabase.ImportAsset(path, ImportAssetOptions.ForceUpdate);
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+            }
+            finally
+            {
+                AssetDatabase.StopAssetEditing();
+            }
+        }
+    }
+
+    public enum EnumFileType 
+    {
+        None = 0,
+        Adr = 1,
+        Agr = 2,
+        Dma = 4,
+        Dme = 8,
+        Map = 16,
+        Gck2 = 32,
+        Gcnk = 64,
+        Gzne = 128,
+        ALL = 255
     }
 }

--- a/Editor/ReimportAllWindow.cs.meta
+++ b/Editor/ReimportAllWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45b90b63aeaa1a44f874e1848c00e075
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Settings.meta
+++ b/Editor/Settings.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4d9ee0d9605b5b543910bcd1303872c6
+guid: 340655c088cf9414f96394a06a4b5886
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Editor/Settings/Settings.cs
+++ b/Editor/Settings/Settings.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace ForgeLightToolkit.Settings
+{
+    public class SettingsEditor
+    {
+        private static Vector2 scrollPos = Vector2.zero;
+        [SettingsProvider]
+        public static SettingsProvider CreateSettingsProvider()
+        {
+            // ensure availability of the instance
+            _ = Settings.Instance;
+
+            var provider = new SettingsProvider("Project/Forgelight Toolkit Settings", SettingsScope.Project)
+            {
+                label = "Forgelight Toolkit Settings",
+                guiHandler = context =>
+                {
+                    SerializedObject settings = new(Settings.Instance);
+
+                    scrollPos = GUILayout.BeginScrollView(scrollPos);
+                    GUILayout.BeginVertical();
+
+                    var invZProp = settings.FindProperty("invertZ");
+                    EditorGUILayout.PropertyField(invZProp, new GUIContent("Invert Z Axis"));
+
+                    GUILayout.EndVertical();
+                    GUILayout.EndScrollView();
+
+                    if (settings.hasModifiedProperties)
+                    {
+                        bool runReimport = invZProp.boolValue != Settings.Instance.InvertZ;
+
+                        settings.ApplyModifiedPropertiesWithoutUndo();
+                        Settings.Instance.save();
+                        
+                        if (runReimport)
+                        {
+                            ReimportAllWindow.ReimportAll();
+                        }
+                    }
+                },
+                keywords = new HashSet<string>() { "Forgelight", "FLTK" }
+            };
+
+            return provider;
+        }
+    }
+
+    public class Settings : ScriptableObject
+    {
+        private const string FilePath = "ProjectSettings/ForgeLightToolKitSettings.json";
+
+        private static Settings _instance;
+        public static Settings Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    _instance = CreateInstance<Settings>();
+                    _instance.load();
+                }
+                return _instance;
+            }
+        }
+
+        public bool InvertZ => invertZ;
+        [SerializeField]
+        private bool invertZ;
+
+        private void initDefaults()
+        {
+            invertZ = false;
+        }
+
+        private void load()
+        {
+            if (!File.Exists(FilePath))
+            {
+                initDefaults();
+                return;
+            }
+
+            try
+            {
+                string jsonText = File.ReadAllText(FilePath);
+                EditorJsonUtility.FromJsonOverwrite(jsonText, this);
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+                initDefaults();
+            }
+        }
+
+        internal void save()
+        {
+            string dirName = Path.GetDirectoryName(FilePath);
+            if (!Directory.Exists(dirName))
+            {
+                Directory.CreateDirectory(dirName);
+            }
+            File.WriteAllText(FilePath, EditorJsonUtility.ToJson(this, true));
+        }
+    }
+}

--- a/Editor/Settings/Settings.cs
+++ b/Editor/Settings/Settings.cs
@@ -28,6 +28,8 @@ namespace ForgeLightToolkit.Settings
 
                     var invZProp = settings.FindProperty("invertZ");
                     EditorGUILayout.PropertyField(invZProp, new GUIContent("Invert Z Axis"));
+                    EditorGUILayout.PropertyField(settings.FindProperty("shaderOverrides"), new GUIContent("Shader Name Overrides"));
+                    EditorGUILayout.PropertyField(settings.FindProperty("modelOverrides"), new GUIContent("Model Name Overrides"));
 
                     GUILayout.EndVertical();
                     GUILayout.EndScrollView();
@@ -74,9 +76,25 @@ namespace ForgeLightToolkit.Settings
         [SerializeField]
         private bool invertZ;
 
+        public List<ShaderOverride> ShaderOverrides => shaderOverrides;
+        [SerializeField]
+        private List<ShaderOverride> shaderOverrides;
+
+        public List<ModelOverride> ModelOverrides => modelOverrides;
+        [SerializeField]
+        private List<ModelOverride> modelOverrides;
+
         private void initDefaults()
         {
             invertZ = false;
+            shaderOverrides = new();
+            modelOverrides = new();
+        }
+
+        private void initNullable()
+        {
+            shaderOverrides ??= new();
+            modelOverrides ??= new();
         }
 
         private void load()
@@ -97,6 +115,8 @@ namespace ForgeLightToolkit.Settings
                 Debug.LogException(e);
                 initDefaults();
             }
+
+            initNullable();
         }
 
         internal void save()
@@ -108,5 +128,55 @@ namespace ForgeLightToolkit.Settings
             }
             File.WriteAllText(FilePath, EditorJsonUtility.ToJson(this, true));
         }
+
+        public Shader GetShader(string name)
+        {
+            foreach (var so in shaderOverrides)
+            {
+                if (so.ShaderName == name)
+                {
+                    return so.Shader;
+                }
+            }
+
+            return null;
+        }
+
+        public GameObject GetModel(string name)
+        {
+            foreach (var mo in modelOverrides)
+            {
+                if (mo.ObjectName == name)
+                {
+                    return mo.Object;
+                }
+            }
+
+            return null;
+        }
+    }
+
+    [Serializable]
+    public class ShaderOverride
+    {
+        public string ShaderName => shaderName;
+        [SerializeField]
+        private string shaderName;
+
+        public Shader Shader => shader;
+        [SerializeField]
+        private Shader shader;
+    }
+
+    [Serializable]
+    public class ModelOverride
+    {
+        public string ObjectName => objName;
+        [SerializeField]
+        private string objName;
+
+        public GameObject Object => obj;
+        [SerializeField]
+        private GameObject obj;
     }
 }

--- a/Editor/Settings/Settings.cs
+++ b/Editor/Settings/Settings.cs
@@ -14,14 +14,14 @@ namespace ForgeLightToolkit.Settings
         public static SettingsProvider CreateSettingsProvider()
         {
             // ensure availability of the instance
-            _ = Settings.Instance;
+            _ = FLTKSettings.Instance;
 
             var provider = new SettingsProvider("Project/Forgelight Toolkit Settings", SettingsScope.Project)
             {
                 label = "Forgelight Toolkit Settings",
                 guiHandler = context =>
                 {
-                    SerializedObject settings = new(Settings.Instance);
+                    SerializedObject settings = new(FLTKSettings.Instance);
 
                     scrollPos = GUILayout.BeginScrollView(scrollPos);
                     GUILayout.BeginVertical();
@@ -34,10 +34,10 @@ namespace ForgeLightToolkit.Settings
 
                     if (settings.hasModifiedProperties)
                     {
-                        bool runReimport = invZProp.boolValue != Settings.Instance.InvertZ;
+                        bool runReimport = invZProp.boolValue != FLTKSettings.Instance.InvertZ;
 
                         settings.ApplyModifiedPropertiesWithoutUndo();
-                        Settings.Instance.save();
+                        FLTKSettings.Instance.save();
                         
                         if (runReimport)
                         {
@@ -52,18 +52,18 @@ namespace ForgeLightToolkit.Settings
         }
     }
 
-    public class Settings : ScriptableObject
+    public class FLTKSettings : ScriptableObject
     {
         private const string FilePath = "ProjectSettings/ForgeLightToolKitSettings.json";
 
-        private static Settings _instance;
-        public static Settings Instance
+        private static FLTKSettings _instance;
+        public static FLTKSettings Instance
         {
             get
             {
                 if (_instance == null)
                 {
-                    _instance = CreateInstance<Settings>();
+                    _instance = CreateInstance<FLTKSettings>();
                     _instance.load();
                 }
                 return _instance;

--- a/Editor/Settings/Settings.cs.meta
+++ b/Editor/Settings/Settings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0e62ffe5798d10749b4eaa08920ed30c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -28,3 +28,6 @@ A Unity package that imports ForgeLight assets within Unity.
 
 * Load World (WIP) - Loads the `.gzne` and all available `.gcnk` files for the chosen world including all the objects and lights (if enabled).
 * Load All Worlds (WIP) - Loads all the available `.gzne` and `.gcnk` files for the chosen world including all the objects and lights (if enabled).
+
+## Default Shaders
+The provided shaders are example shaders based on the inputs of the equivalent Forgelight shaders. They may not be perfect recreations. The provided shaders also have culling disabled. To enable "backface" culling, every shader's `Cull Off` line should be changed to `Cull Front` when the `Invert Z Axis` setting is false, and to `Cull Back` when the `Invert Z Axis` setting is set to true.

--- a/obj.meta
+++ b/obj.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 562529a5bb505f44cb4e1650477bac7e
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Main features are the settings provider and the settings that come with it.

All Changes:
- Fix Bug where DME Mesh objects didn't have a name in the asset database
  - Not having this set caused annoying unity assertion failures on Asset Database code initialized reimport
- Add Utility menu options to reimport FLTK file types or all FLTK files
- Add Invert Z Axis setting
  - This converts from Forgelight's z forward to Unity's z forward, meaning that no -1 scale needs to be applied
- Add Shader Override setting
  - Allows the use of a user-defined shader in place of the shaders in FLTK
- Add Model Override setting
  - Allows the loading of a custom prefab for a given model file name
- Made all shaders have culling off
  - Shaders look correct for both values of Invert Z Axis, at the cost of no "backface" culling
- Remove `bin` and `obj` folder meta files